### PR TITLE
[P-LOW][S-SMALL]: добавила основные стили, margin, padding, border-radius

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,5 +1,8 @@
+import '../assets/global.scss';
+
 function App() {
   return <h1>Привет, мир!</h1>;
 }
 
 export default App;
+

--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -1,12 +1,7 @@
-* {
-margin: 0;
-padding: 0;
-box-sizing: border-box;
-}
-
 :root {
+  --padding-inline: 120px;
+  --padding-blocks: 32px;
   --margin-blocks: 140px;
-  --padding-blocks: 32px 32px;
   --gap-blocks: 20px;
   --border-radius-btn-social: 12px;
   --border-radius-btn: 16px;

--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -1,0 +1,15 @@
+* {
+margin: 0;
+padding: 0;
+box-sizing: border-box;
+}
+
+:root {
+  --margin-blocks: 140px;
+  --padding-blocks: 32px 32px;
+  --gap-blocks: 20px;
+  --border-radius-btn-social: 12px;
+  --border-radius-btn: 16px;
+  --border-radius-blocks: 20px;
+  --border-radius-chat: 24px;
+}


### PR DESCRIPTION
### Добавила** основные стили в файл global.scss.

Изучив макет подробно, добавила часто повторяющиеся переменные для root:

- margin-blocks: Определяет значение отступа (margin) для блоков.
- padding-blocks: Определяет значение внутреннего отступа (padding) для блоков.
- gap-blocks: Определяет значение промежутка (gap) между элементами.
- border-radius-btn-social: Определяет радиус скругления для кнопок социальных сетей(telegram)
- border-radius-btn: Определяет радиус скругления для обычных кнопок.
- border-radius-blocks: Определяет радиус скругления для блоков.
- border-radius-chat: Определяет радиус скругления для элементов чата.

<img width="500" alt="Снимок экрана 2025-02-24 в 13 48 51" src="https://github.com/user-attachments/assets/ac3ad238-4ec8-46ce-bfaa-f198a51ae068" />

Стили подключены в App.tsx
<img width="466" alt="Снимок экрана 2025-02-24 в 14 08 38" src="https://github.com/user-attachments/assets/38636c65-4883-4146-a72a-ff19854a198a" />
