### PR TITLE
Изменила вариант social для Button

### DIFF
--- a/src/assets/styles/globals.scss
+++ b/src/assets/styles/globals.scss
@@ -1,3 +1,9 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
 html,
 body {
   margin: 0;

--- a/src/shared/button/index.module.scss
+++ b/src/shared/button/index.module.scss
@@ -84,7 +84,7 @@
   }
 
   &.social {
-    column-gap: 8px;
+    column-gap: 12px;
     background-color: var(--clr-blue);
     color: var(--clr-main);
     border-radius: var(--border-radius-btn-social);

--- a/src/shared/button/index.tsx
+++ b/src/shared/button/index.tsx
@@ -9,7 +9,8 @@ const Button: React.FC<ButtonProps> = ({
   icon,
   disabled = false,
   className,
-  onClick
+  onClick,
+  href
 }) => {
   const buttonClass = classNames(
     styles.button,
@@ -20,16 +21,22 @@ const Button: React.FC<ButtonProps> = ({
     },
     className
   );
+
+  const ButtonElement = variant === 'social' ? 'a' : 'button';
+
+  const attributes = {
+    className: buttonClass,
+    onClick,
+    disabled,
+    'aria-disabled': disabled,
+    ...(variant === 'social' ? { href, target: '_blank', rel: 'noopener noreferrer' } : {})
+  };
+
   return (
-    <button
-      className={buttonClass}
-      onClick={onClick}
-      disabled={disabled}
-      aria-disabled={disabled}
-    >
-      {icon && <img src={icon} className={styles.icon}></img>}
+    <ButtonElement {...attributes}>
+      {icon && <img src={icon} className={styles.icon} alt="" />}
       {text}
-    </button>
+    </ButtonElement>
   );
 };
 

--- a/src/shared/button/type.ts
+++ b/src/shared/button/type.ts
@@ -6,5 +6,6 @@ export interface ButtonProps {
   icon?: string;
   disabled?: boolean;
   className?: string; // для добавления стилей при необходимости
+  href?: string;
   onClick?: () => void;
 }

--- a/src/shared/button/type.ts
+++ b/src/shared/button/type.ts
@@ -5,7 +5,7 @@ export interface ButtonProps {
   size?: 'large';
   icon?: string;
   disabled?: boolean;
-  className?: string; // для добавления стилей при необходимости
+  className?: string;
   href?: string;
   onClick?: () => void;
 }


### PR DESCRIPTION
Т.к. в макете эта кнопка используется для перехода на внешний ресурс, при выборе варианта 'social' в разметке тег button автоматически заменяется на тег a.
Для url добавлен пропс href.
Атрибуты target: '_blank', rel: 'noopener noreferrer' добавляются автоматически.
Поправила gap:12 px согласно макету.
![Screenshot_2](https://github.com/user-attachments/assets/588bf505-b79c-4fbc-b574-3c76a07728d9)
