### PR TITLE
fix: Исправление багов в AboutService

### DIFF
--- a/src/features/TutorCabinet/ui/AboutService/components/popupContentList/index.tsx
+++ b/src/features/TutorCabinet/ui/AboutService/components/popupContentList/index.tsx
@@ -8,9 +8,11 @@ import styles from './index.module.scss';
 import { IPopupContentList } from './type';
 
 export const PopupContentList: React.FC<IPopupContentList> = ({
-  onListChange
+  onListChange,
+  onErrorChange
 }) => {
   const [items, setItems] = useState<React.ReactNode[]>([]);
+  const [urlErrors, setUrlErrors] = useState<{[key: number]: string}>({});
 
   useEffect(() => {
     if (onListChange) {
@@ -18,8 +20,23 @@ export const PopupContentList: React.FC<IPopupContentList> = ({
     }
   }, [items, onListChange]);
 
+  useEffect(() => {
+    const hasErrors = Object.values(urlErrors).some(error => error !== '');
+    if (onErrorChange) {
+      onErrorChange(hasErrors);
+    }
+  }, [urlErrors, onErrorChange]);
+
+  const handleUrlErrorChange = (index: number, error: string) => {
+    setUrlErrors(prev => ({
+      ...prev,
+      [index]: error
+    }));
+  };
+
   const handleAddClick = () => {
     if (items.length < 10) {
+      const newIndex = items.length;
       setItems([
         ...items,
         <PopupContentURL
@@ -27,6 +44,7 @@ export const PopupContentList: React.FC<IPopupContentList> = ({
           url=""
           readOnly={false}
           key={items.length}
+          onErrorChange={(error) => handleUrlErrorChange(newIndex, error)}
         />
       ]);
     }
@@ -38,6 +56,7 @@ export const PopupContentList: React.FC<IPopupContentList> = ({
       <button
         onClick={handleAddClick}
         className={styles.popup__content_list_button}
+        disabled={items.length >= 10}
       >
         <img
           src={iconAdd}

--- a/src/features/TutorCabinet/ui/AboutService/components/popupContentList/type.ts
+++ b/src/features/TutorCabinet/ui/AboutService/components/popupContentList/type.ts
@@ -1,3 +1,4 @@
 export interface IPopupContentList {
   onListChange?: (items: React.ReactNode[]) => void;
+  onErrorChange?: (hasError: boolean) => void;
 }

--- a/src/features/TutorCabinet/ui/AboutService/components/popupContentURL/index.tsx
+++ b/src/features/TutorCabinet/ui/AboutService/components/popupContentURL/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 
 import unionIcon from '../../../../../../assets/icons/Union.svg';
 
@@ -9,11 +9,24 @@ import { IPopupContentURL } from './type';
 export const PopupContentURL: React.FC<IPopupContentURL> = ({
   inputName,
   url,
-  readOnly = true
+  readOnly = true,
+  onErrorChange
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = useState(url);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (onErrorChange) {
+      onErrorChange(error || '');
+    }
+  }, [error, onErrorChange]);
+
+  useEffect(() => {
+    if (!readOnly && url) {
+      validateInput(url);
+    }
+  }, []);
 
   const handleCopyClick = () => {
     if (inputRef.current) {
@@ -32,11 +45,31 @@ export const PopupContentURL: React.FC<IPopupContentURL> = ({
   };
 
   const validateInput = (value: string) => {
-    if (value.startsWith('https://')) {
-      setError(null);
+    if (!value.trim()) {
+      setError('Поле не может быть пустым');
       return;
     }
-    setError('Пожалуйста, введите корректную ссылку');
+    
+    const invalidChars = /[ <>{}|\\^~\[\]`]/;
+    if (invalidChars.test(value)) {
+      setError('Ссылка содержит недопустимые символы');
+      return;
+    }
+
+    if (value.startsWith('http://') || value.startsWith('https://')) {
+      const protocol = value.startsWith('https://') ? 'https://' : 'http://';
+      const afterProtocol = value.slice(protocol.length);
+      
+      if (!afterProtocol.trim()) {
+        setError('Ссылка должна содержать домен');
+        return;
+      }
+    } else {
+      setError('Ссылка должна начинаться с http:// или https://');
+      return;
+    }
+
+    setError(null);
   };
 
   return (
@@ -48,7 +81,7 @@ export const PopupContentURL: React.FC<IPopupContentURL> = ({
           readOnly={readOnly}
           value={inputValue}
           onChange={handleInputChange}
-          className={styles.popup__content_URL_input}
+          className={`${styles.popup__content_URL_input} ${error ? styles.error : ''}`}
         />
         <button
           onClick={handleCopyClick}

--- a/src/features/TutorCabinet/ui/AboutService/components/popupContentURL/type.ts
+++ b/src/features/TutorCabinet/ui/AboutService/components/popupContentURL/type.ts
@@ -3,4 +3,5 @@ export interface IPopupContentURL {
   url: string;
   readOnly: boolean;
   key?: number;
+  onErrorChange?: (error: string) => void;
 }

--- a/src/features/TutorCabinet/ui/AboutService/index.tsx
+++ b/src/features/TutorCabinet/ui/AboutService/index.tsx
@@ -18,10 +18,11 @@ const AboutService = ({ bonusPopup, reviewPopup }: IAboutService) => {
   const [isBonusPopupOpen, setIsBonusPopupOpen] = useState(false);
   const [isReviewPopupOpen, setIsReviewPopupOpen] = useState(false);
   const [listItems, setListItems] = useState<React.ReactNode[]>([]);
+  const [hasInputError, setHasInputError] = useState(false);
 
   const points = bonusPopup.points;
   const isBonusPopupDisabled = points < 500;
-  const isReviewPopupDisabled = listItems.length === 0;
+  const isReviewPopupDisabled = listItems.length === 0 || hasInputError;
 
   useEffect(() => {
     if (isBonusPopupOpen || isReviewPopupOpen) {
@@ -89,7 +90,10 @@ const AboutService = ({ bonusPopup, reviewPopup }: IAboutService) => {
         URL="#0"
       >
         <PopupContentText text={reviewPopup.text}></PopupContentText>
-        <PopupContentList onListChange={setListItems}></PopupContentList>
+        <PopupContentList 
+          onListChange={setListItems}
+          onErrorChange={setHasInputError}
+        ></PopupContentList>
       </PopupContainer>
     </>
   );


### PR DESCRIPTION
https://github.com/repetitme/repetit-me/issues/305 (На странице репетитора в Личном кабинете в окне Перенос отзывов при вводе некорректной ссылки и появлении сообщения об ошибке, кнопка Отправить активна вместо неактивна)

https://github.com/repetitme/repetit-me/issues/304 (На странице репетитора в Личном кабинете в окне Перенос отзывов при вводе ссылки с недопустимым символом и при вводе только протокола без домена, значение принимается системой, ошибка не появляется)